### PR TITLE
README: Turn the miniKanren.org reference into a link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 miniKanren_org-website
 ======================
 
-Files for the miniKanren.org website.  If you would like to update the site, please do so and send a pull request!
+Files for the [miniKanren.org][site] website.  If you would like to
+update the site, please do so and send a pull request!
+
+ [site]: http://miniKanren.org/


### PR DESCRIPTION
Some people like me use GitHub stars as a way to bookmark things, and getting from GitHub to miniKanren.org without an explicit link involves selecting a piece of text, and copy & pasting it. Making the reference into a link, I can get there in one click.

Signed-off-by: Gergely Nagy algernon@balabit.hu
