### PR TITLE
Fix links to GitHub Pages blogs.

### DIFF
--- a/index.html
+++ b/index.html
@@ -867,11 +867,11 @@ Recorded December 14th, 2012.
 
 <h3><a href="http://swannodette.github.com">David Nolen - dosync</a></h3>
 
-<a href="http://swannodette.github.io/2013/03/25/stlc-redux---part-ii/">STLC Redux: Part II</a><br />
+<a href="http://swannodette.github.io/2013/03/25/stlc-redux-part-ii">STLC Redux: Part II</a><br />
 
-<a href="http://swannodette.github.io/2013/03/09/logic-programming-is-underrated/">Logic Programming is Underrated</a><br />
+<a href="http://swannodette.github.io/2013/03/09/logic-programming-is-underrated">Logic Programming is Underrated</a><br />
 
-<a href="http://swannodette.github.com/Nominal%20Logic/2013/02/08/the-simply-typed-lambda-calculus-in-20-lines-redux/">The Simply Typed Lambda Calculus in 20 Lines Redux</a><br /><br />
+<a href="http://swannodette.github.io/nominal%20logic/2013/02/08/the-simply-typed-lambda-calculus-in-20-lines-redux">The Simply Typed Lambda Calculus in 20 Lines Redux</a><br /><br />
 
 
 From David Nolen's old blog (courtesy of the <a href="https://archive.org">Internet Archive's</a> <a href="https://archive.org/web/">Wayback Machine</a>):</a><br /><br />
@@ -1015,17 +1015,17 @@ From David Nolen's old blog (courtesy of the <a href="https://archive.org">Inter
 
 
 <h3><a href="http://martintrojer.github.io/">Martin Trojer</a></h3>
-<a href="http://martintrojer.github.io/clojure/2012/09/27/some-corelogic-graph-code/">Some core.logic graph code</a><br/>
+<a href="http://martintrojer.github.io/clojure/2012/09/27/some-corelogic-graph-code">Some core.logic graph code</a><br/>
 
-<a href="http://martintrojer.github.io/clojure/2012/08/12/ckanren-time/">cKanren time!</a><br/>
+<a href="http://martintrojer.github.io/clojure/2012/08/12/ckanren-time">cKanren time!</a><br/>
 
-<a href="http://martintrojer.github.io/clojure/2012/07/11/n-queens-with-corelogic-take-2/">Replicating Datomic/Datalog queries with core.logic, take 2</a><br/>
+<a href="http://martintrojer.github.io/clojure/2012/07/11/n-queens-with-corelogic-take-2">Replicating Datomic/Datalog queries with core.logic, take 2</a><br/>
 
-<a href="http://martintrojer.github.io/clojure/2012/07/07/n-queens-with-corelogic-take-1/">Replicating Datomic/Datalog queries with core.logic, take 1</a><br/>
+<a href="http://martintrojer.github.io/clojure/2012/07/07/n-queens-with-corelogic-take-1">Replicating Datomic/Datalog queries with core.logic, take 1</a><br/>
 
-<a href="http://martintrojer.github.io/clojure/2012/07/11/n-queens-with-corelogic-take-2/">N-Queens with core.logic, take 2</a><br/>
+<a href="http://martintrojer.github.io/clojure/2012/07/11/n-queens-with-corelogic-take-2">N-Queens with core.logic, take 2</a><br/>
 
-<a href="http://martintrojer.github.io/clojure/2012/07/07/n-queens-with-corelogic-take-1/">N-Queens with core.logic, take 1</a>
+<a href="http://martintrojer.github.io/clojure/2012/07/07/n-queens-with-corelogic-take-1">N-Queens with core.logic, take 1</a>
 
 
 


### PR DESCRIPTION
Links to blogposts hosted on GitHub Pages became broken, probably due to changes in underlying generator and route handler.
This pull request fixes them.