### PR TITLE
Add a link to Python package named `kanren`

### DIFF
--- a/index.html
+++ b/index.html
@@ -549,6 +549,8 @@ A Prolog implementation of microKanren.
 
 <h3>Python</h3>
 
+<a href="https://github.com/pythological/kanren">kanren</a><br /><br />
+
 <a href="https://github.com/jcoglan/kanrens/tree/master/python">kanrens</a><br /><br />
 
 <a href="https://github.com/jtauber/pykanren">pykanren</a><br /><br />


### PR DESCRIPTION
This PR adds a link to the Python package `kanren`.